### PR TITLE
Fix Rubydocs malformed URL

### DIFF
--- a/src/dex/docs.rb
+++ b/src/dex/docs.rb
@@ -63,7 +63,7 @@ module Dex
 
       # Builds a permalink to RubyDoc
       def permalink
-        link = path.tr("::", "%2F")
+        link = object.path.gsub("::", "%2F")
         link.tr!("?", "%3F")
         link.tr!("#", ":")
 


### PR DESCRIPTION
Closes #14 

It seems I didn't understand what `#tr` does and in this case, it only makes sense to use `#tr` for the single-width value replaces and not the `::`s