### PR TITLE
Fix formatting of Git Doc links

### DIFF
--- a/src/dex/docs.rb
+++ b/src/dex/docs.rb
@@ -28,8 +28,11 @@ module Dex
 
     # Module for helpers for building embeds
     module Embed
-      # For building permalinks
-      RUBYDOC = "https://meew0.github.io/discordrb/master"
+      # For building links to RubyDoc
+      RUBYDOC = "http://www.rubydoc.info/github/meew0/discordrb/master"
+
+      # For building links to Git Docs
+      GITDOC = "https://meew0.github.io/discordrb/master"
 
       # Does this really need explaining?
       RUBY_TACO = "https://cdn.discordapp.com/emojis/315242245274075157.png"
@@ -50,8 +53,8 @@ module Dex
 
         Discordrb::Webhooks::Embed.new(
           color: 0xff0000,
-          url: permalink,
-          title: "[View on RubyDoc]",
+          url: git_link,
+          title: "[View on Git Docs]",
           description: definitions,
           footer: {text: "discordrb v#{Discordrb::VERSION}@#{GIT_VERSION}", icon_url: RUBY_TACO},
         ).tap { |e| yield e if block_given? }
@@ -59,6 +62,14 @@ module Dex
 
       def embed
         new_embed
+      end
+
+      # Builds a link to Git Docs
+      def git_link
+        link = object.path.gsub("::", "/")
+        link.tr!("?", "%3F")
+
+        "#{GITDOC}/#{link}"
       end
 
       # Builds a permalink to RubyDoc

--- a/src/dex/docs.rb
+++ b/src/dex/docs.rb
@@ -69,7 +69,7 @@ module Dex
         link = object.path.gsub("::", "/")
         link.tr!("?", "%3F")
 
-        "#{GITDOC}/#{link}"
+        "#{GITDOC}/#{link}#{link_suffix}"
       end
 
       # Builds a permalink to RubyDoc
@@ -154,6 +154,10 @@ module Dex
     # Describes rendering for objects and modules
     class Object
       include Lookup
+
+      def link_suffix
+        nil
+      end
     end
 
     # Describes rendering for methods
@@ -174,10 +178,16 @@ module Dex
 
     # Describes rendering for instance methods
     class InstanceMethod < Method
+      def link_suffix
+        "-instance_method"
+      end
     end
 
     # Describes rendering for class methods (not sure if needed)
     class ClassMethod < Method
+      def link_suffix
+        "-class_method"
+      end
     end
   end
 end

--- a/src/dex/docs.rb
+++ b/src/dex/docs.rb
@@ -29,10 +29,10 @@ module Dex
     # Module for helpers for building embeds
     module Embed
       # For building links to RubyDoc
-      RUBYDOC = "http://www.rubydoc.info/github/meew0/discordrb/master"
+      RUBYDOC_URL = "http://www.rubydoc.info/github/meew0/discordrb/master"
 
       # For building links to Git Docs
-      GITDOC = "https://meew0.github.io/discordrb/master"
+      GITHUB_PAGES_URL = "https://meew0.github.io/discordrb/master"
 
       # Does this really need explaining?
       RUBY_TACO = "https://cdn.discordapp.com/emojis/315242245274075157.png"
@@ -53,7 +53,7 @@ module Dex
 
         Discordrb::Webhooks::Embed.new(
           color: 0xff0000,
-          url: git_link,
+          url: github_pages_url,
           title: "[View on Git Docs]",
           description: definitions,
           footer: {text: "discordrb v#{Discordrb::VERSION}@#{GIT_VERSION}", icon_url: RUBY_TACO},
@@ -65,11 +65,11 @@ module Dex
       end
 
       # Builds a link to Git Docs
-      def git_link
+      def github_pages_url
         link = object.path.gsub("::", "/")
         link.tr!("?", "%3F")
 
-        "#{GITDOC}/#{link}#{link_suffix}"
+        "#{GITHUB_PAGES_URL}/#{link}#{link_suffix}"
       end
 
       # Builds a permalink to RubyDoc
@@ -78,7 +78,7 @@ module Dex
         link.tr!("?", "%3F")
         link.tr!("#", ":")
 
-        "#{RUBYDOC}/#{link}"
+        "#{RUBYDOC_URL}/#{link}"
       end
     end
 


### PR DESCRIPTION
Since our git docs don't build permalinks, we'll have to settle for inline links which I *think* I've fixed the formatting for