### PR TITLE
Refactor Lookup#render with MessageBuilder DSL

### DIFF
--- a/src/dex.rb
+++ b/src/dex.rb
@@ -2,6 +2,7 @@
 
 require "pry"
 require_relative "dex/bot"
+require_relative "dex/message_builder"
 require_relative "dex/docs"
 require_relative "dex/lenny"
 

--- a/src/dex/message_builder.rb
+++ b/src/dex/message_builder.rb
@@ -6,7 +6,7 @@ module Dex
 
     def self.build(&block)
       instance = new
-      instance.instance_eval(&block)
+      yield instance
       instance.buffer.string
     end
 
@@ -14,37 +14,41 @@ module Dex
       @buffer = StringIO.new
     end
 
-    def write(str)
-      @buffer << str
+    def write(string)
+      @buffer << string
+      string
     end
 
     def newline
-      @buffer << "\n"
+      write("\n")
+    end
+
+    def space
+      write(" ")
     end
 
     def italics
-      @buffer << "*"
+      write("*")
       yield
-      @buffer << "*"
+      write("*")
     end
 
     def bold
-      @buffer << "**"
+      write("**")
       yield
-      @buffer << "**"
+      write("**")
     end
 
     def inline_code_block(inline = true, lang = "rb")
-      @buffer << "`"
+      write("`")
       yield
-      @buffer << "`"
+      write("`")
     end
 
     def code_block(lang = "rb")
-      backticks = "```"
-      @buffer << newline << backticks << lang << newline
+      write("\n```#{lang}\n")
       yield
-      @buffer << newline << backticks << newline
+      write("\n```\n")
     end
   end
 end

--- a/src/dex/message_builder.rb
+++ b/src/dex/message_builder.rb
@@ -1,0 +1,50 @@
+# frozen_string_literal: true
+
+module Dex
+  class MessageBuilder
+    attr_reader :buffer
+
+    def self.build(&block)
+      instance = new
+      instance.instance_eval(&block)
+      instance.buffer.string
+    end
+
+    def initialize
+      @buffer = StringIO.new
+    end
+
+    def write(str)
+      @buffer << str
+    end
+
+    def newline
+      @buffer << "\n"
+    end
+
+    def italics
+      @buffer << "*"
+      yield
+      @buffer << "*"
+    end
+
+    def bold
+      @buffer << "**"
+      yield
+      @buffer << "**"
+    end
+
+    def inline_code_block(inline = true, lang = "rb")
+      @buffer << "`"
+      yield
+      @buffer << "`"
+    end
+
+    def code_block(lang = "rb")
+      backticks = "```"
+      @buffer << newline << backticks << lang << newline
+      yield
+      @buffer << newline << backticks << newline
+    end
+  end
+end

--- a/src/dex/message_builder.rb
+++ b/src/dex/message_builder.rb
@@ -39,7 +39,7 @@ module Dex
       write("**")
     end
 
-    def inline_code_block(inline = true, lang = "rb")
+    def inline_code_block
       write("`")
       yield
       write("`")


### PR DESCRIPTION
This PR refactors our content rendering with a wonderfully expressive and simple DSL for building markdown messages.

This replaces the - for lack of a more colorful term - messy heredoc interpolation which had a bunch of logic woven into it making it unreadable.

While much longer, it should now be way easier to read and extend in the future.

- [x] Needs testing!